### PR TITLE
Component updates: Angular 升級、依賴更新與 AutoMapper 新增

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1063,16 +1063,6 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/@angular/build/node_modules/undici": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
-      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
     "node_modules/@angular/cli": {
       "version": "21.2.13",
       "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-21.2.13.tgz",
@@ -12115,9 +12105,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
-      "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.7.tgz",
+      "integrity": "sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12129,7 +12119,7 @@
         "micromatch": "^4.0.8"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^14.18.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -12479,19 +12469,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-plain-obj": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-plain-object": {
@@ -14903,9 +14880,9 @@
       }
     },
     "node_modules/piscina": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.1.4.tgz",
-      "integrity": "sha512-7uU4ZnKeQq22t9AsmHGD2w4OYQGonwFnTypDypaWi7Qr2EvQIFVtG8J5D/3bE7W123Wdc9+v4CZDu5hJXVCtBg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.2.0.tgz",
+      "integrity": "sha512-DszUCKeVN/5G5QKo6jAVHL8fmKnkJvQ0ACiVgY7YGCq3TUB2oznAOayvZPIAdEThvhczkXR+qm3IHsNXpFCYfA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17208,13 +17185,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.17"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -17808,31 +17785,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-proxy": "^1.17.8",
-        "http-proxy": "^1.18.1",
-        "is-glob": "^4.0.1",
-        "is-plain-obj": "^3.0.0",
-        "micromatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "@types/express": "^4.17.13"
-      },
-      "peerDependenciesMeta": {
-        "@types/express": {
-          "optional": true
-        }
       }
     },
     "node_modules/webpack-dev-server/node_modules/ipaddr.js": {

--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,10 @@
     "tar": "7.5.16",
     "vite": "7.3.5",
     "uuid": "11.1.1",
-    "js-yaml": "4.2.0"
+    "js-yaml": "4.2.0",
+    "undici": "7.28.0",
+    "piscina": "5.2.0",
+    "http-proxy-middleware": "3.0.7"
   },
   "dependencies": {
     "@angular/animations": "^21.2.17",


### PR DESCRIPTION
## 變更摘要

### Commit 1: Component updates
- 元件更新

### Commit 2: chore(deps): 新增 AutoMapper 並更新 client 依賴
- **API/API.csproj** — 新增 AutoMapper 15.1.1
- **client/package.json** — 新增 follow-redirects、minimatch、minimist、tmp

### Commit 3: chore: 升級 Angular 套件至 v21.2.17
- @angular 核心套件從 21.2.15 → 21.2.17
- 新增 esbuild 0.28.1 override

### Commit 4: fix(client): 更新依賴並鎖定版本
- 更新 @angular-devkit/build-angular 至 ^21.2.16
- 鎖定 webpack-dev-server、hono、launch-editor、tar、vite、uuid、js-yaml 版本

### Commit 5: fix(client): 更新依賴套件版本
- 更新多項 client 依賴套件版本