### PR TITLE
chore: Component updates — 依賴升級與專案現代化

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1986,18 +1986,18 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.6.tgz",
+      "integrity": "sha512-QdxmAo/ikZqqRGA8s43ww8lcql6naWRvEz0FFrl6MIlc7Gi6TroXnSdWa5U/kq6fzcpqpHesicQxFZIieZbyIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
+        "@babel/generator": "^7.29.6",
         "@babel/helper-compilation-targets": "^7.28.6",
         "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
+        "@babel/helpers": "^7.29.2",
+        "@babel/parser": "^7.29.3",
         "@babel/template": "^7.28.6",
         "@babel/traverse": "^7.29.0",
         "@babel/types": "^7.29.0",
@@ -2014,6 +2014,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core/node_modules/convert-source-map": {

--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,8 @@
     "js-yaml": "4.2.0",
     "undici": "7.28.0",
     "piscina": "5.2.0",
-    "http-proxy-middleware": "3.0.7"
+    "http-proxy-middleware": "3.0.7",
+    "@babel/core": "7.29.6"
   },
   "dependencies": {
     "@angular/animations": "^21.2.17",


### PR DESCRIPTION
## Summary

此 PR 包含專案依賴套件的升級與現代化更新，主要變更如下：

### 📦 依賴升級
- **Angular** 升級至 v21.2.17，並調整 esbuild 版本
- **Client 端** 多項依賴版本更新與鎖定
- **新增** @babel/core、AutoMapper 等依賴

### 🏗️ 專案結構變更
- 新增 `API.Tests` 測試專案（xUnit + CustomWebApplicationFactory）
- API 專案重構：移除 `Startup.cs`，改為使用 `Program.cs` minimal API 模式
- 新增 Docker 相關設定（`.dockerignore`、`Dockerfile`、`appsettings.Docker.json`、`nginx.conf`）
- 新增 `DEPLOY.md` 部署文件

### 🧹 清理與現代化
- 移除過時的 Protractor e2e 測試
- 移除 `tslint.json`，改用 `eslint.config.js`
- 移除 `tsconfig.base.json`，統整至 `tsconfig.json`
- 移除 `demo.ts`、`WeatherForecast` 範例程式碼

### 📊 變更統計
- **51 個檔案**變更，+16,986 / -12,052 行

### Commits
1. `2831d9b` Component updates
2. `2e1d451` chore(deps): 新增 AutoMapper 並更新 client 依賴
3. `e2802ad` chore: 升級 Angular 套件至 v21.2.17 並調整 esbuild 版本
4. `e8a0687` fix(client): 更新依賴並鎖定版本
5. `4de274b` fix(client): 更新依賴套件版本
6. `0fa5ee7` feat(client): 新增 @babel/core 依賴並更新相關套件版本